### PR TITLE
Optimize file walk algorithm for large repositories

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,9 +77,11 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "glob": "^11.0.0"
+    "glob": "^11.0.0",
+    "minimatch": "^9.0.5"
   },
   "devDependencies": {
+    "@types/minimatch": "^5.1.2",
     "@types/mocha": "^10.0.7",
     "@types/node": "20.x",
     "@types/vscode": "^1.93.0",

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
-import { glob } from "glob";
 import * as path from "path";
 import * as fs from "fs";
+import { minimatch } from "minimatch";
 import { Scope } from "./config";
 
 export function unsetFileScope() {
@@ -13,27 +13,86 @@ export function unsetFileScope() {
 }
 
 export async function setFileScope({ include, exclude }: Scope) {
-  // Convert to exclude paths.
   const cwd = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
-  const includePaths = await glob(include, { cwd });
-  const includeGlobs: Set<string> = new Set();
-  const excludeGlobs: Set<string> = new Set();
-  for (let entry of includePaths) {
-    while (entry !== ".") {
-      includeGlobs.add(entry);
-      entry = path.dirname(entry);
-      excludeGlobs.add(path.join(entry, "*"));
-    }
-  }
-  const excludePaths = await glob(Array.from(excludeGlobs), { cwd, dot: true, ignore: Array.from(includeGlobs) });
+  if (!cwd) return;
 
-  // Convert to valid `files.exclude` setting.
+  // Build exclusion list by walking directory tree
   const setting: { [_: string]: boolean } = Object.create(null);
-  for (const entry of [...excludePaths, ...exclude]) {
-    setting[entry] = true;
+  await collectExcludes(cwd, include, setting);
+
+  // Add explicit excludes
+  for (const excludePath of exclude) {
+    setting[excludePath] = true;
   }
 
-  // Update config.
+  // Update config
   const config = vscode.workspace.getConfiguration("files");
   config.update("exclude", setting);
+}
+
+function isPathWhitelisted(relativePath: string, whitelistPatterns: string[]): boolean {
+  // Normalize path - remove leading ./ and convert to posix style
+  const normPath = relativePath.replace(/\\/g, "/").replace(/^\.\//, "");
+
+  if (normPath === "") {
+    // Always include root
+    return true;
+  }
+
+  for (const pattern of whitelistPatterns) {
+    if (minimatch(normPath, pattern)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function collectExcludes(
+  repoRoot: string,
+  whitelistPatterns: string[],
+  excludes: { [_: string]: boolean }
+): Promise<void> {
+
+  async function walkDir(dirPath: string, depth: number = 0): Promise<void> {
+    const relDir = path.relative(repoRoot, dirPath).replace(/\\/g, "/");
+    const normalizedRelDir = relDir === "." ? "" : relDir;
+
+    // If current directory itself is whitelisted, or any pattern starts with this directory, recurse deeper
+    const isWhitelisted = isPathWhitelisted(normalizedRelDir, whitelistPatterns);
+    const hasChildPatterns = whitelistPatterns.some(pattern =>
+      pattern.startsWith(normalizedRelDir) ||
+      pattern.startsWith(normalizedRelDir + "/")
+    );
+
+    if (isWhitelisted || hasChildPatterns) {
+      try {
+        const entries = await fs.promises.readdir(dirPath);
+        for (const entry of entries) {
+          const entryPath = path.join(dirPath, entry);
+
+          try {
+            const stats = await fs.promises.stat(entryPath);
+            if (stats.isDirectory()) {
+              await walkDir(entryPath, depth + 1);
+            }
+          } catch (err) {
+            // Skip files/directories we can't access
+            continue;
+          }
+        }
+      } catch (err) {
+        // Permission error, skip
+      }
+    } else {
+      // Not whitelisted and no child patterns start with this folder, exclude it
+      if (normalizedRelDir) {
+        const excludePattern = `${normalizedRelDir}/**`;
+        excludes[excludePattern] = true;
+      }
+      // If this is root folder (empty string), do NOT exclude everything!
+    }
+  }
+
+  await walkDir(repoRoot);
 }


### PR DESCRIPTION
The existing implementation for setting the `files.exclude` settings requires scanning the full working directory of all files to generate which paths to exclude. For large repositories with many sub folders this is fairly prohibitive. 

The new logic starts traversing from the root directory, checking if the existing directory matches any of the include patterns. It will skip traversing any directories that don't have a much to the allowed patterns saving on total files needing to be traversed.

# Testing 

- Ran `vsce package`
- Installed plugin locally
- Create an includes config and test it works 
<img width="490" height="221" alt="image" src="https://github.com/user-attachments/assets/d1d395c0-ca1c-462d-bdc2-ce211d051751" />
