### PR TITLE
feat: add shared scope configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Taking [llvm-project](https://github.com/llvm/llvm-project) as an example. If yo
 {
     "scope-focus.activeScope": "LLVM/Clang",
     "scope-focus.scopes": {
+        "*": {                             // optional, will be applied to all scopes
+            "include": ["README.md"],      // will be included in all scopes
+            "exclude": ["**/test"]         // will be excluded from all scopes
+        },
         "LLVM/Clang": {
             "include": ["clang", "llvm"],  // accept globs
             "exclude": ["*/cmake"]         // accept globs

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,13 @@
+export interface ScopeConfig {
+  include?: string[];
+  exclude?: string[];
+}
+
+export interface ScopesConfig {
+  [name: string]: ScopeConfig;
+}
+
 export interface Scope {
   include: string[];
   exclude: string[];
-}
-
-export interface Scopes {
-  [name: string]: Scope;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
-import { Scopes } from "./config";
+import { ScopesConfig } from "./config";
 import { unsetFileScope, setFileScope } from "./file";
 
 async function updateScope(status: vscode.StatusBarItem) {
   const config = vscode.workspace.getConfiguration("scope-focus");
   const activeScope = config.get<string | null>("activeScope", null);
-  const scopes = config.get<Scopes>("scopes")!;
+  const scopes = config.get<ScopesConfig>("scopes")!;
 
   if (activeScope === null) {
     status.text = `$(list-tree) No Scope`;
@@ -19,7 +19,11 @@ async function updateScope(status: vscode.StatusBarItem) {
   } else {
     status.text = `$(list-tree) ${activeScope}`;
     status.backgroundColor = undefined;
-    setFileScope(scopes[activeScope]);
+    const sharedScope = scopes["*"];
+    setFileScope({
+      include: [...(sharedScope?.include ?? []), ...(scopes[activeScope].include ?? [])],
+      exclude: [...(sharedScope?.exclude ?? []), ...(scopes[activeScope].exclude ?? [])],
+    });
   }
 
   if (Object.keys(scopes).length === 0) {
@@ -41,7 +45,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand("scope-focus.switchScope", async () => {
       const config = vscode.workspace.getConfiguration("scope-focus");
-      const scopes = ["No Scope", ...Object.keys(config.get<object>("scopes")!)];
+      const scopes = ["No Scope", ...Object.keys(config.get<object>("scopes")!).filter((key) => key !== "*")];
       const selected = await vscode.window.showQuickPick(scopes, {
         title: "Switch Scope",
         placeHolder: "Select a scope to switch to",


### PR DESCRIPTION
This PR:
- Adds ability to create a shared scope configuration (`*`)
- Makes `include` and `exclude` properties optional

```json
"scope-focus.scopes": {
  "*": {
    "include": ["README.md"],
    "exclude": ["**/test"]
  },
  "LLVM/Clang": {
    "include": ["clang", "llvm"],
    "exclude": ["*/cmake"]
  },
  "Libc": {
    "include": ["libc"]
  }
}
```

Equivalent to:

```json
"scope-focus.scopes": {
  "LLVM/Clang": {
    "include": ["clang", "llvm", "README.md"],
    "exclude": ["*/cmake", "**/test"]
  },
  "Libc": {
    "include": ["libc", "README.md"],
    "exclude": ["**/test"]
  }
}
```